### PR TITLE
Update to Angular2 RC6

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,22 +17,21 @@
     "prepare:package": "cp ./{package.json,README.md} ./release/npm"
   },
   "peerDependencies": {
-    "rxjs": "5.0.0-beta.6",
-    "@angular/core": "2.0.0-rc.4 || 2.0.0-rc.5",
-    "@angular/router": "3.0.0-beta.2 || 3.0.0-rc.1"
+    "@angular/core": "2.0.0-rc.4 || 2.0.0-rc.5 || 2.0.0-rc.6",
+    "@angular/router": "3.0.0-beta.2 || 3.0.0-rc.1 || 3.0.0-rc.2"
   },
   "devDependencies": {
-    "@angular/core": "2.0.0-rc.5",
-    "@angular/router": "3.0.0-rc.1",
-    "@angular/common": "2.0.0-rc.5",
-    "@angular/platform-browser": "2.0.0-rc.5",
-    "@angular/compiler": "2.0.0-rc.5",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.5",
-    "ng2-redux": "^3.3.3",
+    "@angular/core": "2.0.0-rc.6",
+    "@angular/router": "3.0.0-rc.2",
+    "@angular/common": "2.0.0-rc.6",
+    "@angular/platform-browser": "2.0.0-rc.6",
+    "@angular/compiler": "2.0.0-rc.6",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.6",
+    "ng2-redux": "^3.3.9",
     "npm-run-all": "^2.1.1",
     "redux": "^3.5.2",
     "rimraf": "^2.5.2",
-    "rxjs": "5.0.0-beta.6",
+    "rxjs": "5.0.0-beta.11",
     "typescript": "^1.8.10",
     "typings": "^1.0.4",
     "zone.js": "^0.6.8"

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,7 @@
 {
   "globalDependencies": {
     "assertion-error": "registry:dt/assertion-error#1.0.0+20160316155526",
-    "es6-shim": "registry:dt/es6-shim#0.31.2+20160602141504",
+    "core-js": "registry:dt/core-js#0.0.0+20160725163759",
     "jasmine": "registry:dt/jasmine#2.2.0+20160621224255"
   }
 }


### PR DESCRIPTION
This requires switching from es6-shim typings to core-js typings.

I also removed peer dependencies that are already covered by Angular; this will make it easier to update as Angular updates its own dependencies.
