### PR TITLE
Add angular router's NavigationExtras support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,22 +20,22 @@
     "@angular/router": "^3.0.0"
   },
   "devDependencies": {
-    "@angular/common": "^2.0.0",
-    "@angular/compiler": "^2.0.0",
-    "@angular/compiler-cli": "^0.6.2",
-    "@angular/core": "^2.0.0",
-    "@angular/platform-browser": "^2.0.0",
+    "@angular/common": "^2.1.2",
+    "@angular/compiler": "^2.1.2",
+    "@angular/compiler-cli": "^2.1.2",
+    "@angular/core": "^2.1.2",
+    "@angular/platform-browser": "^2.1.2",
     "@angular/platform-browser-dynamic": "^2.0.0",
     "@angular/platform-server": "^2.0.0",
-    "@angular/router": "^3.0.0",
+    "@angular/router": "^3.1.2",
     "@types/core-js": "^0.9.32",
     "@types/jasmine": "^2.2.33",
     "ng2-redux": "^4.0.0-beta.1",
     "redux": "^3.6.0",
     "rimraf": "^2.5.4",
-    "rxjs": "5.0.0-beta.12",
-    "typescript": "^2.0.2",
-    "zone.js": "^0.6.23"
+    "rxjs": "^5.0.0-beta.12",
+    "typescript": "^2.0.8",
+    "zone.js": "^0.6.26"
   },
   "author": "Dag Stuan",
   "license": "MIT"

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,1 +1,8 @@
+import { NavigationExtras } from '@angular/router';
+
 export const UPDATE_LOCATION: string = "ng2-redux-router::UPDATE_LOCATION";
+
+export interface ReduxRouterState {
+  location: string,
+  extras?: NavigationExtras
+}

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -1,17 +1,25 @@
 import { Action } from 'redux';
 
-import { UPDATE_LOCATION } from './actions';
-
-export const DefaultRouterState: string = '';
+import { UPDATE_LOCATION, ReduxRouterState } from './actions';
 
 export interface RouterAction extends Action {
-  payload: string
+  payload: ReduxRouterState | string
 }
 
-export function routerReducer(state: string = DefaultRouterState, action: RouterAction): string {
+export const DefaultRouterState: ReduxRouterState = { location: '' };
+
+
+
+export function routerReducer(state:ReduxRouterState = DefaultRouterState, action: RouterAction): ReduxRouterState {
   switch (action.type) {
     case UPDATE_LOCATION:
-      return action.payload || DefaultRouterState;
+      if(typeof action.payload === 'string') {
+        return {
+          location: action.payload
+        };
+      } else {
+        return action.payload || DefaultRouterState;
+      }
     default:
       return state;
   }


### PR DESCRIPTION
Current implementation discards the rich parametrized navigation that angular router supports with [NavigationExtras](https://angular.io/docs/ts/latest/api/router/index/NavigationExtras-interface.html).

This PR enables using Navigation extras within the payload while keeping compatibility with the current implementation, enabling dispatching events with richer payloads.